### PR TITLE
Add install / unistall demo command

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,17 @@
 		"node": ">=6"
 	},
 	"dependencies": {
-		"dockerode": "3.2.1"
+		"dockerode": "3.2.1",
+		"fs-extra": "^9.1.0",
+		"request": "^2.88.2",
+		"unzip-stream": "^0.3.1"
 	},
 	"devDependencies": {
 		"@types/dockerode": "^3.2.2",
+		"@types/fs-extra": "^9.0.8",
 		"@types/node": "^12.12.6",
+		"@types/request": "^2.48.5",
+		"@types/unzip-stream": "^0.3.0",
 		"typescript": "^4.1.3"
 	}
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -106,14 +106,23 @@ export function printUsage(controller?: ToolController, command?: Command) {
 }
 
 function missingArgError(arg: CommandArg): Error {
-    throw new Error(`Missing required ${arg.name}`);
+    const variants: string = arg.getVariants
+        ? "\n" +
+          formatTable(
+              [["Available variants:", ""], ...arg.getVariants().map(x => [x.name, x.description ?? ""])],
+              { headerSeparator: true }
+          )
+        : "";
+    throw new Error(`Missing required ${arg.name}${variants}`);
 }
 
 function getArgValue(arg: CommandArg, commandLine: CommandLine): string | undefined {
     if (arg.isArg) {
         const value = commandLine.args.splice(0, 1)[0];
         if (value !== undefined) {
-            return value;
+            if (arg.getVariants === undefined) return value;
+            if (arg.getVariants().find(x => x.name === value)) return value;
+            throw missingArgError(arg);
         }
         if (arg.defaultValue !== undefined) {
             return arg.defaultValue;

--- a/src/controllers/js/index.ts
+++ b/src/controllers/js/index.ts
@@ -1,8 +1,10 @@
-import {jsCreateCommand} from "./create";
-import {ToolController} from "../../core";
+import { jsCreateCommand } from "./create";
+import { jsInstallCommand } from "./installDemo";
+import { jsUninstallCommand } from "./uninstallDemo";
+import { ToolController } from "../../core";
 
 export const JsApps: ToolController = {
     name: "js",
     title: "JS Apps",
-    commands: [jsCreateCommand],
+    commands: [jsCreateCommand, jsInstallCommand, jsUninstallCommand],
 };

--- a/src/controllers/js/installDemo.ts
+++ b/src/controllers/js/installDemo.ts
@@ -1,0 +1,32 @@
+import path from "path";
+import { Command, Terminal } from "../../core";
+import { getVariants, demoEnsureInstalled } from "./installer";
+
+export const jsInstallCommand: Command = {
+    name: "install",
+    title: "Install TON demo App",
+    args: [
+        {
+            isArg: true,
+            name: "name",
+            type: "string",
+            getVariants,
+        },
+        {
+            name: "folder",
+            type: "folder",
+        },
+    ],
+    async run(terminal: Terminal, args: { name: string; folder: string }) {
+        const appPath = await demoEnsureInstalled(terminal, args.name, args.folder);
+
+        [
+            `Application is installed in ${appPath}`,
+            ``,
+            "Check README.md or run application:",
+            `$ cd ${path.relative(".", appPath)}`,
+            `$ npm i`,
+            `$ npm start`,
+        ].map(x => terminal.log(x));
+    },
+};

--- a/src/controllers/js/installer.ts
+++ b/src/controllers/js/installer.ts
@@ -1,0 +1,98 @@
+import path from "path";
+import fs from "fs-extra";
+import { Terminal, tondevHome } from "../../core";
+import { downloadFromGithub, formatTable } from "../../core/utils";
+
+const repos: { url: string; root: string }[] = [
+    {
+        url: "https://github.com/tonlabs/sdk-samples/archive/master.zip",
+
+        // Github makes this name when zipping files, so we should just write it here correctly
+        root: "sdk-samples-master",
+    },
+];
+
+export function getVariants() {
+    return [
+        {
+            name: "simple-app",
+            description: "This is the simplest app ever",
+            repository: 0,
+            relPath: "v1/web-pack/simple-app",
+        },
+        {
+            name: "subscription",
+            description: "Sometimes it's better to wait for a push than to poll",
+            repository: 0,
+            relPath: "v1/node-js/core-api/subscription",
+        },
+        {
+            name: "query",
+            description: "Try our queries",
+            repository: 0,
+            relPath: "v1/node-js/core-api/query",
+        },
+    ];
+}
+function getVariant(name: string) {
+    const app = getVariants().find(x => x.name === name);
+    // app !== undefined, but the compliler does't know that
+    if (!app) throw `An error occured while checking if "${name}" is installed`;
+    return app;
+}
+
+export async function demoEnsureInstalled(terminal: Terminal, name: string, folder: string) {
+    const app = getVariant(name);
+
+    // Check if App is installed in the current folder
+    const { url: repoUrl, root: repoRoot } = repos[app.repository];
+    /*
+    appFolder = '/home/tondev/sdk-samples-master/v1/node-js/core-api'
+                |            |                  |                   |
+                |   folder   |     repoRoot     |     app.relPath   |
+    */
+    const appFolder = path.resolve(folder, repoRoot, app.relPath);
+    console.log({ appFolder });
+
+    if (!fs.existsSync(appFolder)) {
+        const _appFolder = path.resolve(tondevHome(), repoRoot, app.relPath);
+        console.log({ _appFolder });
+
+        // Check if App exists in .tondev
+        if (!fs.existsSync(_appFolder)) {
+            terminal.log("Cloning SDK samples respository...");
+            await downloadFromGithub(terminal, repoUrl, tondevHome());
+        }
+        fs.copySync(_appFolder, appFolder);
+    }
+    return appFolder;
+}
+export async function demoUninstall(terminal: Terminal, name: string, folder: string) {
+    const app = getVariant(name);
+
+    // Check if App is installed in the current folder
+    const { root: repoRoot } = repos[app.repository];
+    /*
+    appFolder = '/home/tondev/sdk-samples-master/v1/node-js/core-api'
+                |            |                  |                   |
+                |   folder   |     repoRoot     |     app.relPath   |
+    */
+    const paths = [
+        path.resolve(folder, repoRoot, app.relPath),
+        path.resolve(tondevHome(), repoRoot, app.relPath),
+    ];
+
+    let ok = false;
+    const table = paths.map(folder => {
+        if (fs.existsSync(folder)) {
+            fs.rmdirSync(folder, { recursive: true });
+            ok = true;
+            return [folder, "Removed"];
+        } else {
+            return [folder, "Not found"];
+        }
+    });
+
+    terminal.log(formatTable(table));
+    return ok;
+}

--- a/src/controllers/js/uninstallDemo.ts
+++ b/src/controllers/js/uninstallDemo.ts
@@ -1,0 +1,28 @@
+import { Command, Terminal } from "../../core";
+import { getVariants, demoUninstall } from "./installer";
+
+export const jsUninstallCommand: Command = {
+    name: "uninstall",
+    title: "Uninstall TON demo App",
+    args: [
+        {
+            isArg: true,
+            name: "name",
+            type: "string",
+            getVariants,
+        },
+        {
+            name: "folder",
+            type: "folder",
+        },
+    ],
+    async run(terminal: Terminal, args: { name: string; folder: string }) {
+        const ok: boolean = await demoUninstall(terminal, args.name, args.folder);
+
+        if (ok) {
+            terminal.log("Application uninstalled");
+        } else {
+            terminal.log("Application is not installed");
+        }
+    },
+};

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -47,6 +47,10 @@ export type BaseCommandArg = {
      * Determine that the arg is a CLI arg (not an option).
      */
     isArg?: boolean,
+    /**
+     * Get available CLI argument variants
+     */
+    getVariants?(): {name: string; description?: string}[],
 };
 
 /**

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -5,6 +5,8 @@ import { spawn, SpawnOptionsWithoutStdio } from "child_process";
 import * as http from "http";
 import * as https from "https";
 import * as zlib from "zlib";
+import * as unzip from "unzip-stream";
+import request from "request";
 import { Terminal } from "./index";
 
 export function executableName(name: string): string {
@@ -13,6 +15,26 @@ export function executableName(name: string): string {
 
 export function changeExt(path: string, newExt: string): string {
     return path.replace(/\.[^/.]+$/, newExt);
+}
+
+function downloadAndUnzip(dstPath: string, url: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        request(url)
+            .on("error", reject) // http protocol errors
+            .pipe(
+                unzip
+                    .Extract({ path: dstPath })
+                    .on("error", reject) // unzip errors
+                    .on("close", resolve)
+            );
+    });
+}
+
+export async function downloadFromGithub(terminal: Terminal, srcUrl: string, dstPath: string) {
+    terminal.write(`Downloading from ${srcUrl} to ${dstPath} ...`);
+    if (!fs.existsSync(dstPath)) fs.mkdirSync(dstPath, { recursive: true });
+    await downloadAndUnzip(dstPath, srcUrl);
+    terminal.write("\n");
 }
 
 function downloadAndGunzip(dest: string, url: string): Promise<void> {


### PR DESCRIPTION
Usage:
$ tondev js install  <имя_приложения> [--folder]
$ tondev js uninstall  <имя_приложения> [--folder]

See: https://www.notion.so/tonlabs/tondev-web-demo-project-c136282a3b1c495cb6153183e0e8ac91#54673238833f4d4682c4824a054fb763

The repos are taken from github via https as a zip archive, so the request and unzip-stream packages were added.

Since node.js cannot copy directories recursively, the `fs-extra` package was added

The request package is outdated, but no big deal. If necessary it can be replaced with some modern package.