### PR TITLE
Use --output option, add --export option list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `--force` option for `sol update` and `sol set` commands.
   If set then components will be reinstalled event if they are up to date.
 - `js wrap` command generates JS wrapper file from ABI file and optional TVC file. 
+- help includes commands option variants.
 
 ## [0.3.3] - 2021-03-16
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,75 @@
+import {
+    Command,
+    CommandArg,
+    getArgVariants,
+    ToolController,
+} from "../core";
+import {formatTable} from "../core/utils";
+import fs from "fs";
+import path from "path";
+import {controllers} from "../controllers";
+
+async function printCommandUsage(controller: ToolController, command: Command) {
+    let usageArgs = "";
+    const options: CommandArg[] = [];
+    const args: CommandArg[] = [];
+    for (const arg of command.args ?? []) {
+        if (arg.isArg) {
+            usageArgs += ` ${arg.name}`;
+            args.push(arg);
+        } else {
+            options.push(arg);
+        }
+    }
+    if (options.length > 0) {
+        usageArgs += ` [options]`;
+    }
+    console.log(`Use: tondev ${controller.name} ${command.name}${usageArgs}`);
+    if (args.length > 0) {
+        console.log("Args:");
+        console.log(formatTable(args.map(x => ["  ", x.name, x.title])));
+    }
+    console.log("Options:");
+    const optionsTable = [["  ", "--help, -h", "Show command usage"]];
+    for (const option of options) {
+        optionsTable.push([
+            "  ",
+            `--${option.name}${option.alias ? ", -" + option.alias : ""}`,
+            option.title ?? "",
+        ]);
+        const variants = await getArgVariants(option);
+        if (variants) {
+            formatTable(variants.map(x => [x.value, x.description])).split("\n").forEach(line => {
+                optionsTable.push(["", "", line]);
+            });
+        }
+    }
+    console.log(formatTable(optionsTable));
+}
+
+function printControllerUsage(controller: ToolController) {
+    const commands: [string, Command][] = controller.commands
+        .map(x => [`${controller.name} ${x.name}`, x]);
+    console.log(formatTable(commands.map(x => ["  ", x[0], x[1].title])));
+}
+
+export async function printUsage(controller?: ToolController, command?: Command) {
+    const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf8"));
+    console.log(`TONDev Version: ${pkg.version}`);
+    if (controller && command) {
+        await printCommandUsage(controller, command);
+        return;
+    }
+    console.log(`Use: tondev ${controller?.name ?? "tool"} ${command?.name ?? "command"} args [options]`);
+    console.log(`Options:`);
+    console.log(`    --help, -h  Show command usage`);
+    if (controller) {
+        console.log("Commands:");
+        printControllerUsage(controller);
+        return;
+    }
+    for (const controller of controllers) {
+        console.log(`\n${controller.title ?? controller.name} Commands:\n`);
+        printControllerUsage(controller);
+    }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,9 +158,19 @@ export function printCommandUsage(controller: ToolController, command: Command) 
     }
     console.log("Options:");
     console.log(formatTable([
-        ["  ", "--help, -h", "Show command usage"],
-        ...options.map(x => ["  ", `--${x.name}${x.alias ? ", -" + x.alias : ""}`, x.title]),
-    ]));
+        ['  ', '--help, -h', 'Show command usage'],
+        ...options.flatMap((x) => {
+            const lines = [['  ', `--${x.name}${x.alias ? ', -' + x.alias : ''}`, x.title]]
+            if (x.getVariants) {
+                const variants = x.getVariants()
+                const maxLen = Math.max(...variants.map((v) => v.name.length))
+                for (const v of variants) {
+                    lines.push(['  ', '', `${v.name.padEnd(maxLen)} - ${v.description}`])
+                }
+            }
+            return lines
+        }),
+    ]))
     return;
 }
 

--- a/src/controllers/js/wrap.ts
+++ b/src/controllers/js/wrap.ts
@@ -1,5 +1,6 @@
 import {
     Command,
+    CommandArgVariant,
     Terminal,
 } from "../../core";
 import * as fs from "fs";
@@ -56,22 +57,22 @@ export const jsWrapCommand: Command = {
             alias: "e",
             type: "string",
             title: "Export type and options",
-            getVariants(): { name: string; description?: string }[] {
+            getVariants(): CommandArgVariant[] {
                 return [
                     {
-                        name: "commonjs",
+                        value: "commonjs",
                         description: "Use CommonJS modules (NodeJs)",
                     },
                     {
-                        name: "commonjs-default",
+                        value: "commonjs-default",
                         description: "Use CommonJS modules (NodeJS) with default export",
                     },
                     {
-                        name: "es6",
+                        value: "es6",
                         description: "Use ES6 modules",
                     },
                     {
-                        name: "es6-default",
+                        value: "es6-default",
                         description: "Use ES6 modules with default export",
                     },
                 ];

--- a/src/controllers/js/wrap.ts
+++ b/src/controllers/js/wrap.ts
@@ -49,7 +49,7 @@ export const jsWrapCommand: Command = {
             alias: "o",
             type: "string",
             title: "Set output file name (default is built from source ABI file name)",
-            defaultValue: "false",
+            defaultValue: "",
         },
         {
             name: "export",
@@ -76,7 +76,7 @@ export const jsWrapCommand: Command = {
                     },
                 ];
             },
-            defaultValue: "node",
+            defaultValue: ExportFormat.CommonJs,
         },
     ],
     async run(terminal: Terminal, args: {
@@ -88,9 +88,7 @@ export const jsWrapCommand: Command = {
         const abiPath = path.resolve(process.cwd(), args.file);
         const name = path.basename(abiPath).slice(0, -".abi.json".length);
         const abi = JSON.parse(fs.readFileSync(abiPath, "utf8"));
-        const contractName =  args.output !== 'false' 
-            ? args.output 
-            : `${name.substr(0, 1).toUpperCase()}${name.substr(1)}Contract`;
+        const contractName = `${name.substr(0, 1).toUpperCase()}${name.substr(1)}Contract`;
         const code = [`const ${contractName} = {`];
         const abiCode = JSON
             .stringify(abi, undefined, "    ")

--- a/src/controllers/js/wrap.ts
+++ b/src/controllers/js/wrap.ts
@@ -81,7 +81,9 @@ export const jsWrapCommand: Command = {
         const abiPath = path.resolve(process.cwd(), args.file);
         const name = path.basename(abiPath).slice(0, -".abi.json".length);
         const abi = JSON.parse(fs.readFileSync(abiPath, "utf8"));
-        const contractName = `${name.substr(0, 1).toUpperCase()}${name.substr(1)}Contract`;
+        const contractName =  args.output !== 'false' 
+            ? args.output 
+            : `${name.substr(0, 1).toUpperCase()}${name.substr(1)}Contract`;
         const code = [`const ${contractName} = {`];
         const abiCode = JSON
             .stringify(abi, undefined, "    ")

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -30,6 +30,11 @@ export interface Terminal {
     writeError(text: string): void,
 }
 
+export type CommandArgVariant = {
+    value: string,
+    description?: string,
+}
+
 /**
  * Command argument.
  */
@@ -61,7 +66,7 @@ export type BaseCommandArg = {
     /**
      * Get available CLI argument variants
      */
-    getVariants?(): { name: string; description?: string }[],
+    getVariants?(): CommandArgVariant[] | Promise<CommandArgVariant[]>,
 };
 
 /**
@@ -160,3 +165,13 @@ export function tondevHome() {
     return path.resolve(os.homedir(), ".tondev");
 }
 
+export async function getArgVariants(arg: CommandArg): Promise<CommandArgVariant[] | undefined> {
+    if (!arg.getVariants) {
+        return undefined;
+    }
+    const variants = arg.getVariants();
+    if (variants instanceof Promise) {
+        return await variants;
+    }
+    return variants;
+}


### PR DESCRIPTION
1. Bugfix:  --output option was not used

2. Proposal: Didn't find how the user can see what options are available for the `--export` option.
Added output:
```
$ node cli.js js wrap Contract.abi.json  --help
TONDev Version: 0.4.0
Use: tondev js wrap file [options]
Args:
    file  ABI file
Options:
    --help, -h    Show command usage
    --print, -p   Print code to console
    --output, -o  Set output file name (default is built from source ABI file name)
    --export, -e  Export type and options
                  node         - Use NodeJs modules
                  node-default - Use NodeJs modules with default export
                  es           - Use ES modules
                  es-default   - Use ES modules with default export
````