### PR TITLE
Add "sol compile --output-dir" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - 2021-05-26
+
+### New
+- Added new option `--output-dir, -o` for solidity compiler to store `*.abi.json` and `*.tvc` files in a separate directory.
+   Example: `tondev sol compile hello.sol -o ~/assets`
+
 ## [0.6.0] - 2021-04-28
 
 ### New

--- a/package.json
+++ b/package.json
@@ -36,17 +36,19 @@
 		"node": ">=6"
 	},
 	"dependencies": {
-		"dockerode": "3.2.1",
-		"fs-extra": "^9.1.0",
-		"request": "^2.88.2",
-		"unzip-stream": "^0.3.1",
+		"@tonclient/appkit": "^0",
 		"@tonclient/core": "^1",
 		"@tonclient/lib-node": "^1",
-		"@tonclient/appkit": "^0"
+		"dockerode": "3.2.1",
+		"fs-extra": "^9.1.0",
+		"mv": "^2.1.1",
+		"request": "^2.88.2",
+		"unzip-stream": "^0.3.1"
 	},
 	"devDependencies": {
 		"@types/dockerode": "^3.2.2",
 		"@types/fs-extra": "^9.0.8",
+		"@types/mv": "^2.1.1",
 		"@types/node": "^12.12.6",
 		"@types/request": "^2.48.5",
 		"@types/unzip-stream": "^0.3.0",

--- a/src/controllers/solidity/index.ts
+++ b/src/controllers/solidity/index.ts
@@ -10,6 +10,7 @@ import {
     uniqueFilePath,
 } from "../../core/utils";
 import fs from "fs";
+import mv from 'mv';
 import {BasicContract} from "./snippets";
 import {components} from "./components";
 
@@ -83,7 +84,16 @@ export const solidityCompileCommand: Command = {
             ["compile", codeName, "--lib", components.stdlib.path]);
 
         const generatedTvcName = `${/Saved contract to file (.*)$/mg.exec(linkerOut)?.[1]}`;
-        fs.renameSync(path.resolve(fileDir, generatedTvcName), path.resolve(outputDir, tvcName));
+
+        // fs.renameSync was replaces by this code, because of an error: EXDEV: cross-device link not permitted
+        await new Promise((res, rej) =>
+            mv(
+                path.resolve(fileDir, generatedTvcName),
+                path.resolve(outputDir, tvcName),
+                { mkdirp: true, clobber: true },
+                (err: Error) => (err ? rej(err) : res(true)),
+            )
+        );
         fs.unlinkSync(path.resolve(fileDir, codeName));
     },
 };

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -199,6 +199,8 @@ export function run(
 ): Promise<string> {
     return new Promise((resolve, reject) => {
         try {
+            const { cwd } = options
+            if (cwd && !fs.existsSync(cwd)) throw Error(`Directory not exists: ${cwd}`)
             const isWindows = os.platform() === "win32";
             const spawned = isWindows
                 ? spawn("cmd.exe", ["/c", name].concat(args), {


### PR DESCRIPTION
New option was called "--output-dir", as it is called in sol compiler

The following cases have been tested:
```
tondev sol compile Contract.sol
tondev sol compile Contract.sol -o abc               # relative path
tondev sol compile Contract.sol -o /home/ruser  #absolute path

tondev sol compile abc/Contract.sol                   # absolute path
tondev sol compile abc/Contract.sol -o abc
tondev sol compile abc/Contract.sol -o /home/ruser
```
