### PR TITLE
Fixed incorrect parsing initial data params with options --data, -d.

### DIFF
--- a/src/controllers/contract/accounts.ts
+++ b/src/controllers/contract/accounts.ts
@@ -80,6 +80,7 @@ export async function getAccount(terminal: Terminal, args: {
         options.initData = ParamParser.components({
             name: "data",
             type: "tuple",
+            components: abiData
         }, args.data);
     }
     if (address !== "") {


### PR DESCRIPTION
Adding "components" property when call `ParamParser.components()`.