### PR TITLE
NEW: `signer list` column `used` with references to this (e.g., as a …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.4] - 2021-06-25
+
+### New
+
+- add `signer list` column `used` with references to this (e.g., as a signer for network giver).
+- `network list` column `giver` add information about giver contract and signer.
+- printed tables now supports multiline cell values.
+
+### Fixed
+
+- "Error: Signer not found:" in case when the default signer has upper letters in name.
+- Giver didn't use default signer. From now the giver uses default signer 
+  when the user calls the `network giver` command without `--signer` option. 
+
 ## [0.7.3] - 2021-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### New
 
-- add `signer list` column `used` with references to this (e.g., as a signer for network giver).
-- `network list` column `giver` add information about giver contract and signer.
-- printed tables now supports multiline cell values.
+- Column `used` was added to  `signer list` with reference to the giver that uses this signer;
+- Column `giver` was added to `network list` with information about giver's contract and signer.
+- Printed tables now supports multiline cell values.
 
 ### Fixed
 
 - "Error: Signer not found:" in case when the default signer has upper letters in name.
-- Giver didn't use default signer. From now the giver uses default signer 
-  when the user calls the `network giver` command without `--signer` option. 
+- Giver didn't use default signer. From now the giver uses default signer when User calls the `network giver` command without `--signer` option. 
 
 ## [0.7.3] - 2021-06-03
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tondev",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"description": "TON Dev Environment",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/controllers/network/giver.ts
+++ b/src/controllers/network/giver.ts
@@ -16,6 +16,7 @@ import {
     KnownContracts,
 } from "../../core/known-contracts";
 import {NetworkGiverInfo} from "./registry";
+import {SignerRegistry} from "../signer/registry";
 
 async function giverV2Send(giver: Account, address: string, value: number): Promise<void> {
     await giver.run("sendTransaction", {
@@ -63,8 +64,9 @@ export class NetworkGiver implements AccountGiver {
         client: TonClient,
         info: NetworkGiverInfo,
     ): Promise<NetworkGiver> {
-        const signer = info.signer !== ""
-            ? await createSigner(info.signer)
+        const signerName = (info.signer || new SignerRegistry().default) ?? "";
+        const signer = signerName !== ""
+            ? await createSigner(signerName)
             : signerKeys(seGiverKeys);
         const address = info.address !== ""
             ? info.address

--- a/src/controllers/network/index.ts
+++ b/src/controllers/network/index.ts
@@ -5,6 +5,7 @@ import {
     ToolController,
 } from "../../core";
 import {
+    getGiverSummary,
     NetworkRegistry,
 } from "./registry";
 import {
@@ -60,11 +61,12 @@ export const networkListCommand: Command = {
         const registry = new NetworkRegistry();
         const rows = [["Network", "Endpoints", "Giver", "Description"]];
         registry.items.forEach((network) => {
+            const summary = registry.getNetworkSummary(network);
             rows.push([
-                `${network.name}${network.name === registry.default ? " (Default)" : ""}`,
-                NetworkRegistry.getEndpointsSummary(network),
-                network.giver?.address ?? "",
-                network.description ?? "",
+                summary.name,
+                summary.endpoints,
+                summary.giver,
+                summary.description,
             ]);
         });
         const table = formatTable(rows, { headerSeparator: true });
@@ -94,10 +96,7 @@ export const networkInfoCommand: Command = {
         rows.push(["Endpoints", network.endpoints.join(", ")]);
         const giver = network.giver;
         if (giver) {
-            rows.push([
-                "Giver",
-                `${giver.name} at ${giver.address}${giver.signer ? ` signed by ${giver.signer}` : ""}`,
-            ]);
+            rows.push(["Giver", getGiverSummary(giver)]);
         }
         if (network.name === registry.default) {
             rows.push(["Default", "true"]);

--- a/src/controllers/network/registry.ts
+++ b/src/controllers/network/registry.ts
@@ -31,6 +31,25 @@ export type Network = {
     giver?: NetworkGiverInfo,
 }
 
+type NetworkSummary = {
+    name: string,
+    endpoints: string,
+    giver: string,
+    description: string,
+}
+
+export function getGiverSummary(giver?: NetworkGiverInfo): string {
+    if (!giver) {
+        return "";
+    }
+    const {
+        signer,
+        name,
+        address,
+    } = giver;
+    return `${address}\n${name}${signer ? ` signed by ${signer}` : ""}`;
+}
+
 export class NetworkRegistry {
     readonly items: Network[] = [];
     default?: string;
@@ -172,6 +191,15 @@ export class NetworkRegistry {
             ? network.endpoints
             : [...network.endpoints.slice(0, maxEndpoints), "..."];
         return endpoints.join(", ");
+    }
+
+    getNetworkSummary(network: Network): NetworkSummary {
+        return {
+            name: `${network.name}${network.name === this.default ? " (Default)" : ""}`,
+            endpoints: NetworkRegistry.getEndpointsSummary(network),
+            giver: getGiverSummary(network.giver),
+            description: network.description ?? "",
+        };
     }
 }
 

--- a/src/controllers/signer/index.ts
+++ b/src/controllers/signer/index.ts
@@ -14,6 +14,7 @@ import {
     TonClient,
 } from "@tonclient/core";
 import {formatTable} from "../../core/utils";
+import {NetworkRegistry} from "../network/registry";
 
 const nameArg: CommandArg = {
     isArg: true,
@@ -171,12 +172,17 @@ export const signerListCommand: Command = {
     args: [],
     async run(terminal: Terminal, _args: {}) {
         const registry = new SignerRegistry();
-        const rows = [["Signer", "Public Key", "Description"]];
-        registry.items.forEach(x => rows.push([
-            `${x.name}${x.name === registry.default ? " (Default)" : ""}`,
-            x.keys.public,
-            x.description,
-        ]));
+        const networks = new NetworkRegistry();
+        const rows = [["Signer", "Public Key", "Used", "Description"]];
+        registry.items.forEach(x => {
+            const summary = registry.getSignerSummary(x, networks);
+            rows.push([
+                summary.name,
+                summary.public,
+                summary.used,
+                summary.description,
+            ]);
+        });
         const table = formatTable(rows, { headerSeparator: true });
         if (table.trim() !== "") {
             terminal.log(table);


### PR DESCRIPTION
…signer for network giver).

NEW: `network list` column `giver` add information about giver contract and signer.
NEW: printed tables now supports multiline cell values.
FIX: "Error: Signer not found:" in case when the default signer has upper letters in name.
FIX: Giver didn't use default signer. From now the giver uses default signer
  when the user calls the `network giver` command without `--signer` option.