### PR TITLE
closes #41, closes #42; Fixed: Set clang complier version, clarified …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.5] - 2021-07-15
+
+### Fixed
+
+- "tondev clang set --compiler" didn't change installed compiler version https://github.com/tonlabs/tondev/issues/42
+
+
 ## [0.7.4] - 2021-06-25
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.7.5] - 2021-07-15
+## [0.8.0] - 2021-07-15
 
 ### Fixed
 

--- a/src/controllers/clang/components.ts
+++ b/src/controllers/clang/components.ts
@@ -26,7 +26,7 @@ function clangHome() {
 }
 
 export const components = {
-    clang: new (class extends Component {
+    compiler: new (class extends Component {
         getSourceName(version: string): string {
             return `${this.name}/${this.name}-${version.split(".").join("_")}-${ext}`;
         }

--- a/src/controllers/clang/index.ts
+++ b/src/controllers/clang/index.ts
@@ -27,7 +27,7 @@ export const clangCreateCommand: Command = {
         {
             name: "folder",
             type: "folder",
-            title: "Target folder (current is default)",
+            title: "Target folder (should exist, current by default)",
         },
     ],
     async run(terminal: Terminal, args: { name: string; folder: string }) {
@@ -67,7 +67,7 @@ export const clangCompileCommand: Command = {
         const generatedAbiName = changeExt(args.file, ".abi");
         const renamedAbiName = changeExt(args.file, ".abi.json");
 
-        await components.clang.run(
+        await components.compiler.run(
             terminal,
             path.dirname(args.file), // cd to this directory
             [args.file, "-o", tvcName]


### PR DESCRIPTION
Fixes #42 
Now to check:
```
$ cd tondev
$ npm i
$ tsc
$ node cli.js clang version
Component  Available
---------  --------------------------------------------------------------------------
compiler   7.7.0, 7.6.0, 7.5.0, 7.4.10, 7.4.9, 7.4.8, 7.4.7, 7.4.5, 7.4.3, 7.4.1, ...

$ node cli.js clang update
Component  Version  Available
---------  -------  --------------------------------------------------------------------------
compiler   7.7.0    7.7.0, 7.6.0, 7.5.0, 7.4.10, 7.4.9, 7.4.8, 7.4.7, 7.4.5, 7.4.3, 7.4.1, ...

$ node cli.js clang set -c 7.4.8
Component  Version  Available
---------  -------  --------------------------------------------------------------------------
compiler   7.4.8    7.7.0, 7.6.0, 7.5.0, 7.4.10, 7.4.9, 7.4.8, 7.4.7, 7.4.5, 7.4.3, 7.4.1, ...
```
