### PR TITLE
Change deployment top-up logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.2] - 2021-08-20
+
+### Fixed
+- an error that occurred when a contract was deployed to an account with a positive balance less than the default (10 tokens) and Giver was not set properly.
+
+For contract deployment, the following logic was implemented:
+
+Giver will top-up an account if:
+ - User has explicitly requested this by specifying the `-v <VALUE>` option
+   or
+ - Account balance is zero. In this case, the default amount (10 tokens) is sent
+
 ## [0.8.1] - 2021-07-26
 
 ### Fixed

--- a/src/controllers/network/giver.ts
+++ b/src/controllers/network/giver.ts
@@ -62,7 +62,7 @@ export class NetworkGiver implements AccountGiver {
         });
     }
 
-    static async get(
+    static async create(
         client: TonClient,
         info: NetworkGiverInfo,
     ): Promise<NetworkGiver> {

--- a/src/controllers/network/registry.ts
+++ b/src/controllers/network/registry.ts
@@ -170,7 +170,7 @@ export class NetworkRegistry {
         const network = this.get(name);
         const client = new TonClient({ network: { endpoints: network.endpoints } });
         try {
-            const giver = await NetworkGiver.get(client, {
+            const giver = await NetworkGiver.create(client, {
                 name: "",
                 address,
                 signer,


### PR DESCRIPTION
For contract deployment, top-up logic was changed
Now giver will send tokens if:
 - User has explicitly requested this by specifying the `-v <VALUE>` option
   or
 - Account balance is zero. In this case, the default amount (10 tokens) is sent
