### PR TITLE
Formatting has been extracted from the loadBinaryVersions function to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - Dependabot cannot update ssh2 to a non-vulnerable version
 
+- `tondev sol set` can now install any existing binaries by version number, not just one of the last ten
+
 ## [0.10.2] - 2021-09-24
 
 ### Fixed

--- a/src/controllers/ts4/components.ts
+++ b/src/controllers/ts4/components.ts
@@ -69,7 +69,7 @@ export const components = {
                 .filter(v => (/^(\d+\.){2}\d+$/).test(v))
                 .sort(compareVersions)
                 .reverse()
-            return versions.length < 10 ? versions : [...versions.slice(0, 10), "..."]
+            return versions
         }
     }('', PYTHON, {
         isExecutable: true,

--- a/src/controllers/ts4/index.ts
+++ b/src/controllers/ts4/index.ts
@@ -14,7 +14,7 @@ export const ts4VersionCommand: Command = {
 
 export const ts4InstallCommand: Command = {
     name: "install",
-    title: "Install latest release of TestSuite4",
+    title: "Install a specific release of TestSuite4",
     args: [{
         isArg: true,
         name: 'version',

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import {
     downloadFromBinaries,
+    ellipsisString,
     executableName,
     formatTable,
     loadBinaryVersions,
@@ -201,10 +202,11 @@ export class Component {
             if (version === "") {
                 hasNotInstalledComponents = true;
             }
+            const allVersions = await component.loadAvailableVersions()
             table.push([
                 name,
                 version !== "" ? version : "not installed",
-                (await component.loadAvailableVersions()).join(", "),
+                ellipsisString(allVersions)
             ]);
         }
         let info = formatTable(table, { headerSeparator: true });

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -20,10 +20,14 @@ export function changeExt(path: string, newExt: string): string {
     return path.replace(/\.[^/.]+$/, newExt);
 }
 
+export function ellipsisString(xs: string[]): string {
+    return (xs.length < 10 ? xs : [...xs.slice(0, 10), '...']).join(', ')
+}
+
 export async function loadBinaryVersions(name: string): Promise<string[]> {
     const info = await httpsGetJson(`https://binaries.tonlabs.io/${name}.json`);
     const versions = info[name].sort(compareVersions).reverse();
-    return versions.length < 10 ? versions : [...versions.slice(0, 10), "..."];
+    return versions
 }
 
 export function formatTokens(nanoTokens: string | number | bigint): string {


### PR DESCRIPTION
… a separate one.

Output format of ` tondev sol version` has not changed, but now it's possible to install any existing binary version.
```
$ tondev sol version
Component  Version  Available
---------  -------  ---------------------------------------------------------------------------------------------
compiler   0.47.0   0.50.0, 0.49.0, 0.48.0, 0.47.0, 0.46.0, 0.45.0, 0.44.0, 0.43.0, 0.42.0, 0.41.0, ...
linker     0.13.24  0.13.55, 0.13.54, 0.13.53, 0.13.52, 0.13.50, 0.13.48, 0.13.47, 0.13.46, 0.13.42, 0.13.40, ...
stdlib     0.49.0   0.50.0, 0.49.0, 0.48.0, 0.47.0, 0.46.0, 0.45.0, 0.44.0, 0.43.0, 0.42.0, 0.41.0, ...
```
But it is possible to install any specific version, e.g.
```
$ tondev sol set -c 0.38.1
Downloading from https://binaries.tonlabs.io/solc_0_38_1_linux.gz.........................................................................................................
Component  Version  Available
---------  -------  ---------------------------------------------------------------------------------------------
compiler   0.38.1   0.50.0, 0.49.0, 0.48.0, 0.47.0, 0.46.0, 0.45.0, 0.44.0, 0.43.0, 0.42.0, 0.41.0, ...
linker     0.13.24  0.13.55, 0.13.54, 0.13.53, 0.13.52, 0.13.50, 0.13.48, 0.13.47, 0.13.46, 0.13.42, 0.13.40, ...
stdlib     0.49.0   0.50.0, 0.49.0, 0.48.0, 0.47.0, 0.46.0, 0.45.0, 0.44.0, 0.43.0, 0.42.0, 0.41.0, ...
```
 