### PR TITLE
Add check before run-local

### DIFF
--- a/src/controllers/contract/index.ts
+++ b/src/controllers/contract/index.ts
@@ -406,6 +406,9 @@ export const contractRunLocalCommand: Command = {
         preventUi: boolean,
     }) {
         const account = await getAccount(terminal, args);
+
+        await guardAccountIsActive(account)
+
         const {
             functionName,
             functionInput,
@@ -467,6 +470,18 @@ export const contractRunExecutorCommand: Command = {
     },
 };
 
+const guardAccountIsActive = async (acc: Account) => {
+    const { active, uninit, frozen } = AccountType
+    const { acc_type: accType } = await acc.getAccount()
+    if (accType === active) return
+    const status =
+        accType === uninit
+            ? 'is not initialized'
+            : accType === frozen
+            ? 'is frozen'
+            : 'does not exist'
+    throw Error(`Account ${await acc.getAddress()} ${status}`)
+}
 
 export const Contract: ToolController = {
     name: "contract",


### PR DESCRIPTION
Added check that account is "active" before starting `run-local`
```
$ node cli.js contract run-local contracts/SetcodeMultisigWallet.abi.json -a 0:982e134f8e9755a1662975a0beb598daa3259510a947906295c73cf9f0d95e27

Configuration
  Network: dev (net.ton.dev, net1.ton.dev, net5.ton.dev)
  Signer:  None

Address:   0:982e134f8e9755a1662975a0beb598daa3259510a947906295c73cf9f0d95e27

Error: Account 0:982e134f8e9755a1662975a0beb598daa3259510a947906295c73cf9f0d95e27 does not exist
```
Didn't add this check  before `run` and `run-executor` because these commands throw their own meaningful errors if the account is inactive.