### PR TITLE
Add old solc and linker to compile SafeMultisigWallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.5] - 2021-11-11
+### NEW
+- Added the ability to compile [SafeMultisigWallet](https://github.com/tonlabs/ton-labs-contracts/tree/master/solidity/safemultisig) for Linux platform. The size of the compiled contract will be different from the original due to a different linker, but the compiler is the same
+
+Install the appropriate compiler, linker, and stdlib versions:
+```
+tondev sol set -c 0.21.0
+tondev sol set -s 0.21.0
+tondev sol set -l 0.1.21
+```
+Now you can compile SafeMultisigWallet contract:
+```
+tondev sol compile SafeMultisigWallet.sol
+ls -l SafeMultisigWallet.tvc
+-rw-rw-r--. 1 4430 Nov 11 22:16 SafeMultisigWallet.tvc
+```
+
 ## [0.10.4] - 2021-09-27
 
 - `tondev contract run-local` now checks the contract state before execution and generates user friendly error, if contract does not exist or is in uninit or frozen state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tondev",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "TON Dev Environment",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -47,18 +47,18 @@
 		"unzip-stream": "^0.3.1"
 	},
 	"devDependencies": {
+		"@babel/preset-env": "^7.14.7",
+		"@babel/preset-typescript": "^7.14.5",
 		"@types/dockerode": "^3.2.2",
 		"@types/fs-extra": "^9.0.8",
+		"@types/jest": "^26.0.23",
 		"@types/mv": "^2.1.1",
 		"@types/node": "^12.12.6",
 		"@types/request": "^2.48.5",
 		"@types/unzip-stream": "^0.3.0",
 		"caxa": "^1.0.0",
-		"typescript": "^4.1.3",
-		"@babel/preset-env": "^7.14.7",
-		"@babel/preset-typescript": "^7.14.5",
-		"@types/jest": "^26.0.23",
 		"jest": "^27.0.6",
-		"ts-jest": "^27.0.3"
+		"ts-jest": "^27.0.3",
+		"typescript": "^4.1.3"
 	}
 }

--- a/src/controllers/solidity/index.ts
+++ b/src/controllers/solidity/index.ts
@@ -92,11 +92,11 @@ export const solidityCompileCommand: Command = {
         const abiName = path.resolve(outputDir, changeExt(fileName, ".abi.json"));
         const codeName = path.resolve(outputDir, changeExt(fileName, ".code"));
 
-        const isDepricatedVersion = (await components.compiler.getCurrentVersion()) <= '0.21.0'
+        const isDeprecatedVersion = (await components.compiler.getCurrentVersion()) <= '0.21.0'
 
         let linkerOut: string;
 
-        if (isDepricatedVersion) {
+        if (isDeprecatedVersion) {
             terminal.log("You use an obsolete version of the compiler.\nThe output files are saved in the current directory");
 
             await components.compiler.silentRun(terminal, fileDir, [ fileName]);

--- a/src/controllers/solidity/index.ts
+++ b/src/controllers/solidity/index.ts
@@ -89,14 +89,31 @@ export const solidityCompileCommand: Command = {
         const outputDir = path.resolve(args.outputDir ?? ".");
         const preserveCode = args.code;
         const tvcName = path.resolve(outputDir, changeExt(fileName, ".tvc"));
+        const abiName = path.resolve(outputDir, changeExt(fileName, ".abi.json"));
         const codeName = path.resolve(outputDir, changeExt(fileName, ".code"));
 
-        await components.compiler.silentRun(terminal, fileDir, ["-o", outputDir, fileName]);
-        const linkerOut = await components.linker.silentRun(
-            terminal,
-            fileDir,
-            ["compile", codeName, "--lib", components.stdlib.path()],
-        );
+        const isDepricatedVersion = (await components.compiler.getCurrentVersion()) <= '0.21.0'
+
+        let linkerOut: string;
+
+        if (isDepricatedVersion) {
+            terminal.log("You use an obsolete version of the compiler.\nThe output files are saved in the current directory");
+
+            await components.compiler.silentRun(terminal, fileDir, [ fileName]);
+            linkerOut = await components.linker.silentRun(
+                terminal,
+                fileDir,
+                ["compile", codeName, "-a", abiName,  "--lib", components.stdlib.path()],
+            );
+        } else {
+            await components.compiler.silentRun(terminal, fileDir, ["-o", outputDir, fileName]);
+            linkerOut = await components.linker.silentRun(
+                terminal,
+                fileDir,
+                ["compile", codeName, "--lib", components.stdlib.path()],
+            );
+        }
+
         const generatedTvcName = `${/Saved contract to file (.*)$/mg.exec(linkerOut)?.[1]}`;
 
         // fs.renameSync was replaces by this code, because of an error: EXDEV: cross-device link not permitted

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -103,8 +103,11 @@ export class Component {
 
     async resolveVersion(_downloadedVersion: string): Promise<string> {
         if (fs.existsSync(this.path())) {
+            const isDepricatedVersion = !!(_downloadedVersion.match(/^0.21.0$|^0.1.21$/))
             const compilerOut = await this.run(nullTerminal, process.cwd(), ["--version"]);
-            return compilerOut.match(this.resolveVersionRegExp)?.[1] ?? "";
+            return isDepricatedVersion
+                ? _downloadedVersion
+                : compilerOut.match(this.resolveVersionRegExp)?.[1] ?? ''
         }
         return "";
     }

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -103,9 +103,9 @@ export class Component {
 
     async resolveVersion(_downloadedVersion: string): Promise<string> {
         if (fs.existsSync(this.path())) {
-            const isDepricatedVersion = !!(_downloadedVersion.match(/^0.21.0$|^0.1.21$/))
+            const isDeprecatedVersion = !!(_downloadedVersion.match(/^0.21.0$|^0.1.21$/))
             const compilerOut = await this.run(nullTerminal, process.cwd(), ["--version"]);
-            return isDepricatedVersion
+            return isDeprecatedVersion
                 ? _downloadedVersion
                 : compilerOut.match(this.resolveVersionRegExp)?.[1] ?? ''
         }


### PR DESCRIPTION
See CHANGELOG

Steps to test:
1. Check that old functionality still works
```
$ npm i
$ tsc
$ rm -rf ~/.tondev/solidity/
$ node cli.js sol create
$ node cli.js sol compile Contract.sol 
Solidity contract Contract.sol created.

$ node cli.js sol version
Component  Version  Available
---------  -------  ---------------------------------------------------------------------------------------------
compiler   0.51.0   0.51.0, 0.50.0, 0.49.0, 0.48.0, 0.47.0, 0.46.0, 0.45.0, 0.44.0, 0.43.0, 0.42.0, ...
linker     0.13.88  0.13.88, 0.13.87, 0.13.86, 0.13.85, 0.13.84, 0.13.83, 0.13.82, 0.13.73, 0.13.72, 0.13.71, ...
stdlib     0.51.0   0.51.0, 0.50.0, 0.49.0, 0.48.0, 0.47.0, 0.46.0, 0.45.0, 0.44.0, 0.43.0, 0.42.0, ...
[tiger@localhost tondev]$ 
```
2. Check that new functionality works
```
$ curl https://raw.githubusercontent.com/tonlabs/ton-labs-contracts/master/solidity/safemultisig/SafeMultisigWallet.sol -o SafeMultisigWallet.sol

$ node cli.js sol set -c 0.21.0
$ node cli.js  sol set -s 0.21.0
$ node cli.js sol set -l 0.1.21
$ node cli.js sol compile  SafeMultisigWallet.sol 
You use an obsolete version of the compiler.
The output files are saved in the current directory

$ ls -l SafeMultisigWallet.tvc 
-rw-rw-r--. 1 4430 Nov 11 23:03 SafeMultisigWallet.tvc
```
OK. now we can compile SafeMultisigWallet

