### PR TITLE
Remove file extension checking

### DIFF
--- a/src/controllers/solidity/index.ts
+++ b/src/controllers/solidity/index.ts
@@ -77,11 +77,6 @@ export const solidityCompileCommand: Command = {
         outputDir: string,
         code: boolean,
     }): Promise<void> {
-        const ext = path.extname(args.file);
-        if (ext !== ".sol") {
-            terminal.log(`Choose solidity source file.`);
-            return;
-        }
         await Component.ensureInstalledAll(terminal, components);
         const fileDir = path.dirname(args.file);
         const fileName = path.basename(args.file);


### PR DESCRIPTION
We don't need to check file extension, because '.sol' uses for Solidity language, not for Solidity-TON. For example, we have a project for bridge, there we want to have '.sol' for Ethereum and '.solt' for Solidity-TON, with this checking the file extension we won't be able to compile '.solt'